### PR TITLE
Added error and general object log support

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -29,16 +29,23 @@ function Pattern(pattern) {
                 message: appenderFmt + textFormat.text,
                 otherArgs: _.drop(args, textFormat.argCount)
             };
-
+        } else if (logText instanceof Error) {
+            return {
+                message: appenderFmt + logText.message + '\n' + logText.stack,
+                otherArgs: _.concat(args, logText)
+            };
+        // Assume it is an object and simply try to show its contents
+        } else {
+            return {
+                message: appenderFmt + JSON.stringify(logText),
+                otherArgs: _.concat(args, logText)
+            };
         }
+
         return {
             message: appenderFmt,
             otherArgs: _.concat(args, logText)
         };
-
-
-
-
     }
 }
 

--- a/spec/zlog.spec.js
+++ b/spec/zlog.spec.js
@@ -30,6 +30,26 @@ describe('zlog', function () {
         expect(stdout.writeLog).toHaveBeenCalled();
     });
 
+    it('should handle an error object log', function () {
+        var logger = zlog.getLogger('myLogger');
+        logger.error(new Error());
+        expect(stdout.writeLog).toHaveBeenCalled();
+
+        // The full error with stack trace should be printed
+        var errorLog = String(stdout.writeLog.calls.argsFor(0)[2]);
+        expect(errorLog.indexOf('zlog.spec.js') > -1).toEqual(true);
+    });
+
+    it('should handle an object passed in', function () {
+        var logger = zlog.getLogger('myLogger');
+        logger.error({ my: 'object' });
+        expect(stdout.writeLog).toHaveBeenCalled();
+
+        // The full error with stack trace should be printed
+        var errorLog = String(stdout.writeLog.calls.argsFor(0)[2]);
+        expect(errorLog.split('- ')[1]).toEqual('{"my":"object"}');
+    });
+
     it('should show the log on default console appender when using console.log and level is info', function () {
         zlog.setRootLogger('INFO');
         console.log('hello');


### PR DESCRIPTION
Now statements like `logger.error(new Error());` and `logger.error({ my: 'object' });` properly show what was sent in.