### PR TITLE
Revert "Added error and general object log support"

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -29,23 +29,16 @@ function Pattern(pattern) {
                 message: appenderFmt + textFormat.text,
                 otherArgs: _.drop(args, textFormat.argCount)
             };
-        } else if (logText instanceof Error) {
-            return {
-                message: appenderFmt + logText.message + '\n' + logText.stack,
-                otherArgs: _.concat(args, logText)
-            };
-        // Assume it is an object and simply try to show its contents
-        } else {
-            return {
-                message: appenderFmt + JSON.stringify(logText),
-                otherArgs: _.concat(args, logText)
-            };
-        }
 
+        }
         return {
             message: appenderFmt,
             otherArgs: _.concat(args, logText)
         };
+
+
+
+
     }
 }
 

--- a/spec/zlog.spec.js
+++ b/spec/zlog.spec.js
@@ -30,26 +30,6 @@ describe('zlog', function () {
         expect(stdout.writeLog).toHaveBeenCalled();
     });
 
-    it('should handle an error object log', function () {
-        var logger = zlog.getLogger('myLogger');
-        logger.error(new Error());
-        expect(stdout.writeLog).toHaveBeenCalled();
-
-        // The full error with stack trace should be printed
-        var errorLog = String(stdout.writeLog.calls.argsFor(0)[2]);
-        expect(errorLog.indexOf('zlog.spec.js') > -1).toEqual(true);
-    });
-
-    it('should handle an object passed in', function () {
-        var logger = zlog.getLogger('myLogger');
-        logger.error({ my: 'object' });
-        expect(stdout.writeLog).toHaveBeenCalled();
-
-        // The full error with stack trace should be printed
-        var errorLog = String(stdout.writeLog.calls.argsFor(0)[2]);
-        expect(errorLog.split('- ')[1]).toEqual('{"my":"object"}');
-    });
-
     it('should show the log on default console appender when using console.log and level is info', function () {
         zlog.setRootLogger('INFO');
         console.log('hello');


### PR DESCRIPTION
Reverts z-open/zlog#5

This pull request did not go thru the regular process. It should not have not been approved without final review from project owner.

The issue was not in Zlog, but in a custom appender implementation which did not deal with the output properly.
To be addressed. There is missing documentation in Zlog that led to incorrect implementation.
